### PR TITLE
Ensure viewer sessions ignore headless step guardrail

### DIFF
--- a/mujoco_template/runtime.py
+++ b/mujoco_template/runtime.py
@@ -309,7 +309,7 @@ class PassiveRunHarness:
                 steps = run_passive_viewer(
                     env,
                     duration=resolved.viewer.duration_seconds,
-                    max_steps=resolved.simulation.max_steps,
+                    max_steps=None,
                     hooks=hooks,
                 )
             elif video_encoder is not None:


### PR DESCRIPTION
## Summary
- prevent passive viewer runs from inheriting the simulation max-step guardrail that is meant for headless execution
- add regression tests that stub the recorder and viewer to confirm interactive sessions ignore the guardrail and still honor explicit durations

## Testing
- `PYTHONPATH=. pytest` *(fails: FFmpeg executable 'ffmpeg' not found on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d5316ee45883228707104c92916d36