### PR TITLE
Improve drone LQR stability diagnostics

### DIFF
--- a/examples/drone/drone_config.py
+++ b/examples/drone/drone_config.py
@@ -55,12 +55,12 @@ TRAJECTORY = SimpleNamespace(
 
 CONTROLLER = SimpleNamespace(
     keyframe="hover",
-    linearization_eps=1e-6,
+    linearization_eps=1e-5,
     position_weight=18.0,
-    orientation_weight=4.0,
+    orientation_weight=8.0,
     velocity_weight=8.0,
-    angular_velocity_weight=2.0,
-    control_weight=1.4,
+    angular_velocity_weight=6.0,
+    control_weight=2.0,
     clip_controls=True,
     goal_position_m=TRAJECTORY.goal_position_m,
     goal_orientation_wxyz=TRAJECTORY.goal_orientation_wxyz,

--- a/examples/drone/drone_lqr.py
+++ b/examples/drone/drone_lqr.py
@@ -121,6 +121,11 @@ class DroneLQRController:
 
         P, K = self._solve_lqr_gains(A, B, Q, R)
 
+        closed_loop = A - B @ K
+        eigvals = np.linalg.eigvals(closed_loop)
+        spectral_radius = float(np.max(np.abs(eigvals)))
+        print(f"Closed-loop spectral radius: {spectral_radius:.9f}")
+
         self._qpos_goal = qpos_goal
         self._qpos_start = qpos_start
         self._qvel_goal = qvel_goal


### PR DESCRIPTION
## Summary
- increase the drone example LQR conditioning parameters and yaw-related weights to reduce saturation-induced instability
- emit the closed-loop spectral radius after solving for the gains to aid hover diagnostics

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d60f6f7cc08322a5aaac8f1429d6e1