### PR TITLE
Allow adaptive camera to recenter on multiple axes

### DIFF
--- a/mujoco_template/adaptive_camera.py
+++ b/mujoco_template/adaptive_camera.py
@@ -58,9 +58,10 @@ class AdaptiveCameraSettings:
     max_fovy: float = 80.0
     min_ortho_height: float = 0.5
     max_ortho_height: float = 25.0
-    recenter_axis: str | None = None
+    recenter_axis: str | Sequence[str] | None = None
     recenter_time_constant: float = 1.0
     points_of_interest: Sequence[str] = field(default_factory=tuple)
+    _recenter_axes: tuple[str, ...] = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if self.zoom_policy not in {"distance", "fov", "orthographic"}:
@@ -89,12 +90,39 @@ class AdaptiveCameraSettings:
             raise ConfigError("Orthographic height bounds must be positive.")
         if self.min_ortho_height > self.max_ortho_height:
             raise ConfigError("min_ortho_height must be <= max_ortho_height.")
-        if self.recenter_axis is not None and self.recenter_axis not in {"x", "y", "z"}:
-            raise ConfigError("recenter_axis must be one of {'x', 'y', 'z'} when provided.")
+        axes_input = self.recenter_axis
+        axes: tuple[str, ...]
+        if axes_input is None:
+            axes = ()
+        else:
+            if isinstance(axes_input, str):
+                raw_axes = (axes_input,)
+            else:
+                raw_axes = tuple(axes_input)
+
+            normalized: list[str] = []
+            for axis in raw_axes:
+                if not isinstance(axis, str):
+                    raise ConfigError("recenter_axis entries must be strings when provided.")
+                token = axis.strip().lower()
+                if token not in {"x", "y", "z"}:
+                    raise ConfigError(
+                        "recenter_axis values must be drawn from {'x', 'y', 'z'} when provided."
+                    )
+                normalized.append(token)
+
+            seen: set[str] = set()
+            axes = tuple(ax for ax in normalized if not (ax in seen or seen.add(ax)))
+
+        object.__setattr__(self, "_recenter_axes", axes)
         if self.recenter_time_constant < 0:
             raise ConfigError("recenter_time_constant must be >= 0.")
         if self.smoothing_time_constant < 0:
             raise ConfigError("smoothing_time_constant must be >= 0.")
+
+    @property
+    def recenter_axes(self) -> tuple[str, ...]:
+        return self._recenter_axes
 
 
 class _PointResolver:
@@ -239,7 +267,7 @@ class AdaptiveFramingController:
         self._widen_threshold = float(settings.widen_threshold)
         self._tighten_threshold = float(settings.tighten_threshold)
         self._zoom_tau = float(settings.smoothing_time_constant)
-        self._recentering_axis = settings.recenter_axis
+        self._recentering_axes = tuple({"x": 0, "y": 1, "z": 2}[axis] for axis in settings.recenter_axes)
         self._recentering_tau = float(settings.recenter_time_constant)
 
         self._original_fovy = float(model.vis.global_.fovy)
@@ -304,17 +332,17 @@ class AdaptiveFramingController:
         if points is None:
             return
 
-        if self._recentering_axis is not None:
-            axis_idx = {"x": 0, "y": 1, "z": 2}[self._recentering_axis]
-            axis_vals = points[:, axis_idx]
-            midpoint = float((axis_vals.min() + axis_vals.max()) * 0.5)
-            self._lookat_target[axis_idx] = midpoint
-            self._lookat_state[axis_idx] = _exp_smoothing(
-                self._lookat_state[axis_idx],
-                self._lookat_target[axis_idx],
-                dt,
-                self._recentering_tau,
-            )
+        if self._recentering_axes:
+            for axis_idx in self._recentering_axes:
+                axis_vals = points[:, axis_idx]
+                midpoint = float((axis_vals.min() + axis_vals.max()) * 0.5)
+                self._lookat_target[axis_idx] = midpoint
+                self._lookat_state[axis_idx] = _exp_smoothing(
+                    self._lookat_state[axis_idx],
+                    self._lookat_target[axis_idx],
+                    dt,
+                    self._recentering_tau,
+                )
 
         self._camera.lookat[:] = self._lookat_state
 


### PR DESCRIPTION
## Summary
- allow `AdaptiveCameraSettings.recenter_axis` to accept multiple axes and normalize the configuration
- recenter the adaptive framing controller along each requested axis instead of a single axis
- add a regression test that exercises simultaneous X/Z recentering

## Testing
- PYTHONPATH=. pytest tests/test_mujoco_template.py::test_adaptive_camera_recenters_along_axis tests/test_mujoco_template.py::test_adaptive_camera_recenters_multiple_axes

------
https://chatgpt.com/codex/tasks/task_e_68d6490d3a28832283beb9a7a3847e31