### PR TITLE
Preserve per-substep instrumentation and extend observations

### DIFF
--- a/mujoco_template/__init__.py
+++ b/mujoco_template/__init__.py
@@ -18,7 +18,7 @@ from .exceptions import (
 from .jacobians import compute_requested_jacobians
 from .linearization import linearize_discrete
 from .model import ModelHandle
-from .observations import ObservationExtractor, ObservationSpec
+from .observations import ObservationExtractor, ObservationProducer, ObservationSpec
 from .setpoints import steady_ctrl0
 from .video import VideoEncoderSettings, VideoExporter, RenderHook, CameraUpdater
 from .runtime import (
@@ -88,6 +88,7 @@ __all__ = [
     "ControllerCapabilities",
     "ObservationSpec",
     "ObservationExtractor",
+    "ObservationProducer",
     "ModelHandle",
     "CompatibilityReport",
     "StepResult",

--- a/mujoco_template/_typing.py
+++ b/mujoco_template/_typing.py
@@ -7,7 +7,19 @@ ObservationArray = np.ndarray
 Observation = ObservationDict | ObservationArray
 JacobianDict = dict[str, np.ndarray]
 JacobiansDict = dict[str, JacobianDict]
-InfoDict = dict[str, str | float | int | np.ndarray | list[str] | JacobiansDict]
+InfoDict = dict[
+    str,
+    str
+    | float
+    | int
+    | np.ndarray
+    | list[str]
+    | JacobiansDict
+    | list[np.ndarray]
+    | tuple[np.ndarray, ...]
+    | list[JacobiansDict]
+    | tuple[JacobiansDict, ...]
+]
 StateSnapshot = dict[str, np.ndarray | float | None]
 
 __all__ = [


### PR DESCRIPTION
## Summary
- accumulate per-substep linearizations and jacobians instead of overwriting them in `Env.step`
- add an extensible `ObservationProducer` hook so `ObservationSpec` can expose custom MuJoCo signals
- expand typings and tests to cover the new observation extras and multi-substep instrumentation behaviour

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8fd9aebc08322b3154806d3048f42