### PR TITLE
Remove unused passive-run sample stride configuration

### DIFF
--- a/examples/cartpole/cartpole.py
+++ b/examples/cartpole/cartpole.py
@@ -148,8 +148,6 @@ def summarize(result):
 
     columns = _resolve_primary_columns(result.env.model)
     column_index = recorder.column_index
-    stride = max(1, result.settings.simulation.sample_stride)
-
     time_idx = column_index[columns["time"]]
     cart_pos_idx = column_index[columns["cart_pos"]]
     cart_vel_idx = column_index[columns["cart_vel"]]
@@ -158,8 +156,7 @@ def summarize(result):
     force_idx = column_index[columns["force"]]
     tip_z_idx = column_index[columns["tip_z"]]
 
-    for idx in range(0, len(rows), stride):
-        row = rows[idx]
+    for row in rows:
         print(
             "t={:5.2f}s cart={:6.3f}m cartdot={:6.3f}m/s pole={:6.2f}deg poledot={:6.2f}deg/s force={:6.2f}N tip_z={:6.3f}m".format(
                 float(row[time_idx]),

--- a/examples/cartpole/cartpole_config.py
+++ b/examples/cartpole/cartpole_config.py
@@ -11,7 +11,6 @@ RUN_SETTINGS = mt.PassiveRunSettings.from_flags(
     simulation_overrides=dict(
         max_steps=2000,  # Positive integer >=1; increase for longer episodes before forced termination.
         duration_seconds=None,  # Either None for unlimited wall-clock time or any positive float cap (seconds).
-        sample_stride=50,  # Positive integer >=1 controlling log decimation; 1 records every step, higher skips samples.
     ),
     video_overrides=dict(
         path=Path("cartpole.mp4"),  # Any pathlib.Path or string target (e.g. ".mov", nested directories, network mounts).

--- a/examples/drone/drone_config.py
+++ b/examples/drone/drone_config.py
@@ -12,7 +12,6 @@ RUN_SETTINGS = mt.PassiveRunSettings.from_flags(
     simulation_overrides=dict(
         max_steps=4000,  # Positive integer >=1; bump upward for longer flights before forced stop.
         duration_seconds=8.0,  # Either None for unlimited wall-clock time or any positive float seconds cap.
-        sample_stride=80,  # Positive integer >=1; lower numbers store denser telemetry, higher sparsify logs.
     ),
     video_overrides=dict(
         path=Path("drone_lqr.mp4"),  # Any Path/str target (e.g. "outputs/run1.mp4" or alternate container extensions).

--- a/examples/humanoid/humanoid_config.py
+++ b/examples/humanoid/humanoid_config.py
@@ -10,7 +10,6 @@ RUN_SETTINGS = mt.PassiveRunSettings.from_flags(
     simulation_overrides=dict(
         max_steps=6000,  # Positive integer >=1; raise for longer rollouts.
         duration_seconds=6.0,  # None removes the wall-clock limit; otherwise supply any positive float seconds cap.
-        sample_stride=120,  # Positive integer >=1; 1 logs every step, larger values thin the dataset.
     ),
     video_overrides=dict(
         path=Path("humanoid_lqr.mp4"),  # Path/str output target (e.g. change extension to .mov or folder prefixes).

--- a/examples/pendulum/pendulum.py
+++ b/examples/pendulum/pendulum.py
@@ -65,16 +65,13 @@ def summarize(result):
 
     columns = resolve_pendulum_columns(result.env.model)
     column_index = recorder.column_index
-    stride = max(1, result.settings.simulation.sample_stride)
-
     time_idx = column_index[columns["time"]]
     angle_idx = column_index[columns["angle"]]
     velocity_idx = column_index[columns["velocity"]]
     ctrl_idx = column_index[columns["ctrl"]]
     tip_z_idx = column_index[columns["tip_z"]]
 
-    for idx in range(0, len(rows), stride):
-        row = rows[idx]
+    for row in rows:
         print(
             "t={:5.3f}s angle={:6.2f}deg vel={:6.2f}deg/s torque={:6.3f}Nm tip_z={:6.3f}m".format(
                 float(row[time_idx]),

--- a/examples/pendulum/pendulum_config.py
+++ b/examples/pendulum/pendulum_config.py
@@ -10,7 +10,6 @@ RUN_SETTINGS = mt.PassiveRunSettings.from_flags(
     simulation_overrides=dict(
         max_steps=400,  # Positive integer >=1 controlling the hard stop on physics steps.
         duration_seconds=None,  # None for unlimited wall-clock time; any positive float caps runtime in seconds.
-        sample_stride=80,  # Positive integer >=1; 1 stores every step, higher values decimate the log.
     ),
     video_overrides=dict(
         path=Path("pendulum.mp4"),  # Path/str for the exported clip (use different extensions or directories as desired).

--- a/examples/pendulum/pendulum_passive.py
+++ b/examples/pendulum/pendulum_passive.py
@@ -36,15 +36,12 @@ def summarize(result):
 
     columns = resolve_pendulum_columns(result.env.model)
     column_index = recorder.column_index
-    stride = max(1, result.settings.simulation.sample_stride)
-
     time_idx = column_index[columns["time"]]
     angle_idx = column_index[columns["angle"]]
     velocity_idx = column_index[columns["velocity"]]
     tip_z_idx = column_index[columns["tip_z"]]
 
-    for idx in range(0, len(rows), stride):
-        row = rows[idx]
+    for row in rows:
         print(
             f"t={row[time_idx]:5.3f}s angle={np.rad2deg(row[angle_idx]):6.2f}deg "
             f"vel={np.rad2deg(row[velocity_idx]):6.2f}deg/s tip_z={row[tip_z_idx]:6.3f}m"

--- a/examples/pendulum/pendulum_passive_config.py
+++ b/examples/pendulum/pendulum_passive_config.py
@@ -10,7 +10,6 @@ RUN_SETTINGS = mt.PassiveRunSettings.from_flags(
     simulation_overrides=dict(
         max_steps=600,  # Positive integer >=1; extend for longer simulations before force-stop.
         duration_seconds=None,  # None removes the wall-clock cap; otherwise provide any positive float seconds limit.
-        sample_stride=120,  # Positive integer >=1 controlling log decimation (1 logs every step).
     ),
     video_overrides=dict(
         path=Path("pendulum_passive.mp4"),  # Path/str for the exported movie (change directories or extensions freely).

--- a/mujoco_template/runtime.py
+++ b/mujoco_template/runtime.py
@@ -100,11 +100,10 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class SimulationSettings:
-    """Control maximum steps, duration, and sampling cadence for passive runs."""
+    """Control maximum steps and duration for passive runs."""
 
     max_steps: int = 2000
     duration_seconds: float | None = None
-    sample_stride: int = 50
 
     def __post_init__(self) -> None:
         if self.max_steps < 1:
@@ -113,8 +112,6 @@ class SimulationSettings:
             raise ConfigError(
                 "SimulationSettings.duration_seconds must be > 0 when provided"
             )
-        if self.sample_stride < 1:
-            raise ConfigError("SimulationSettings.sample_stride must be >= 1")
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ include-package-data = true
 [tool.setuptools.package-data]
 "mujoco_template" = ["mujoco.pyi"]
 
+[tool.pytest.ini_options]
+pythonpath = "."
+
 [tool.mypy]
 strict = true
 warn_return_any = true

--- a/tests/test_mujoco_template.py
+++ b/tests/test_mujoco_template.py
@@ -788,7 +788,7 @@ def test_passive_settings_from_flags_merges_overrides(tmp_path: Path) -> None:
         viewer=True,
         video=True,
         logging=False,
-        simulation_overrides={"max_steps": 42, "sample_stride": 5},
+        simulation_overrides={"max_steps": 42, "duration_seconds": 1.25},
         video_overrides={"path": video_path, "fps": 24.0},
         viewer_overrides={"duration_seconds": 1.5},
         logging_overrides={"path": log_path, "store_rows": True},
@@ -800,7 +800,7 @@ def test_passive_settings_from_flags_merges_overrides(tmp_path: Path) -> None:
     assert settings.video.path == video_path
     assert settings.video.fps == pytest.approx(24.0)
     assert settings.simulation.max_steps == 42
-    assert settings.simulation.sample_stride == 5
+    assert settings.simulation.duration_seconds == pytest.approx(1.25)
     assert settings.logging.enabled is False
     assert settings.logging.path == log_path
     assert settings.logging.store_rows is True


### PR DESCRIPTION
## Summary
- drop the unused `sample_stride` parameter from passive-run simulation settings
- update tests and example scripts/configs to stop referencing the removed field
- configure pytest to resolve the package without requiring `PYTHONPATH=.`

## Testing
- pytest
- PYTHONPATH=. python examples/cartpole/cartpole.py --duration 0.1
- PYTHONPATH=. python examples/pendulum/pendulum.py --duration 0.1
- PYTHONPATH=. python examples/pendulum/pendulum_passive.py --duration 0.1
- PYTHONPATH=. python examples/drone/drone_lqr.py --duration 0.1
- PYTHONPATH=. python examples/humanoid/humanoid_lqr.py --duration 0.1

------
https://chatgpt.com/codex/tasks/task_e_68d9111bfa948322ac842b5a5bbd97cd