### PR TITLE
Simplify imports in example scripts

### DIFF
--- a/examples/cartpole/run_pid.py
+++ b/examples/cartpole/run_pid.py
@@ -1,18 +1,12 @@
 import sys
-from importlib import import_module
 from pathlib import Path
 
-if __package__ is None or __package__ == "":  # pragma: no cover - direct script execution
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
-try:  # Support both `python -m` and direct script execution.
-    from .cartpole_config import CONFIG
-    from .scenarios import HARNESS, summarize
-except ImportError:  # pragma: no cover - fallback for `python examples/cartpole/run_pid.py`
-    CONFIG = import_module("examples.cartpole.cartpole_config").CONFIG  # type: ignore[attr-defined]
-    _scenarios = import_module("examples.cartpole.scenarios")
-    HARNESS = _scenarios.HARNESS
-    summarize = _scenarios.summarize
+from examples.cartpole.cartpole_config import CONFIG
+from examples.cartpole.scenarios import HARNESS, summarize
 
 
 def main(argv=None):

--- a/examples/drone/run_lqr.py
+++ b/examples/drone/run_lqr.py
@@ -1,20 +1,14 @@
 import sys
-from importlib import import_module
 from pathlib import Path
 
 import numpy as np
 
-if __package__ is None or __package__ == "":  # pragma: no cover - direct script execution
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
-try:  # Support both `python -m` and direct script execution.
-    from .drone_config import CONFIG
-    from .scenarios import HARNESS, summarize
-except ImportError:  # pragma: no cover - fallback for `python examples/drone/run_lqr.py`
-    CONFIG = import_module("examples.drone.drone_config").CONFIG  # type: ignore[attr-defined]
-    _scenarios = import_module("examples.drone.scenarios")
-    HARNESS = _scenarios.HARNESS
-    summarize = _scenarios.summarize
+from examples.drone.drone_config import CONFIG
+from examples.drone.scenarios import HARNESS, summarize
 
 
 def main(argv=None):

--- a/examples/humanoid/run_lqr.py
+++ b/examples/humanoid/run_lqr.py
@@ -1,18 +1,12 @@
 import sys
-from importlib import import_module
 from pathlib import Path
 
-if __package__ is None or __package__ == "":  # pragma: no cover - direct script execution
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
-try:  # Support both `python -m` and direct script execution.
-    from .humanoid_config import CONFIG
-    from .scenarios import HARNESS, summarize
-except ImportError:  # pragma: no cover - fallback for `python examples/humanoid/run_lqr.py`
-    CONFIG = import_module("examples.humanoid.humanoid_config").CONFIG  # type: ignore[attr-defined]
-    _scenarios = import_module("examples.humanoid.scenarios")
-    HARNESS = _scenarios.HARNESS
-    summarize = _scenarios.summarize
+from examples.humanoid.humanoid_config import CONFIG
+from examples.humanoid.scenarios import HARNESS, summarize
 
 
 def main(argv=None):

--- a/examples/pendulum/run_passive.py
+++ b/examples/pendulum/run_passive.py
@@ -1,18 +1,12 @@
 import sys
-from importlib import import_module
 from pathlib import Path
 
-if __package__ is None or __package__ == "":  # pragma: no cover - direct script execution
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
-try:  # Support both `python -m` and direct script execution.
-    from .pendulum_passive_config import CONFIG
-    from .scenarios import PASSIVE_HARNESS, summarize_passive
-except ImportError:  # pragma: no cover - fallback for `python examples/pendulum/run_passive.py`
-    CONFIG = import_module("examples.pendulum.pendulum_passive_config").CONFIG  # type: ignore[attr-defined]
-    _scenarios = import_module("examples.pendulum.scenarios")
-    PASSIVE_HARNESS = _scenarios.PASSIVE_HARNESS
-    summarize_passive = _scenarios.summarize_passive
+from examples.pendulum.pendulum_passive_config import CONFIG
+from examples.pendulum.scenarios import PASSIVE_HARNESS, summarize_passive
 
 
 def main(argv=None):

--- a/examples/pendulum/run_pd.py
+++ b/examples/pendulum/run_pd.py
@@ -1,18 +1,12 @@
 import sys
-from importlib import import_module
 from pathlib import Path
 
-if __package__ is None or __package__ == "":  # pragma: no cover - direct script execution
-    sys.path.append(str(Path(__file__).resolve().parents[2]))
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
-try:  # Support both `python -m` and direct script execution.
-    from .pendulum_config import CONFIG
-    from .scenarios import PD_HARNESS, summarize_pd
-except ImportError:  # pragma: no cover - fallback for `python examples/pendulum/run_pd.py`
-    CONFIG = import_module("examples.pendulum.pendulum_config").CONFIG  # type: ignore[attr-defined]
-    _scenarios = import_module("examples.pendulum.scenarios")
-    PD_HARNESS = _scenarios.PD_HARNESS
-    summarize_pd = _scenarios.summarize_pd
+from examples.pendulum.pendulum_config import CONFIG
+from examples.pendulum.scenarios import PD_HARNESS, summarize_pd
 
 
 def main(argv=None):


### PR DESCRIPTION
## Summary
- simplify import setup across example entry points so they support direct execution
- remove python -m oriented fallbacks in favor of straightforward absolute imports

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9323d5a1483228849a1957ab0c16f